### PR TITLE
Proto type override

### DIFF
--- a/protobuf-codegen/src/test/java/com/julienviet/protobuf/tests/codegen/ProcessorTest.java
+++ b/protobuf-codegen/src/test/java/com/julienviet/protobuf/tests/codegen/ProcessorTest.java
@@ -16,6 +16,7 @@
  */
 package com.julienviet.protobuf.tests.codegen;
 
+import com.julienviet.protobuf.tests.codegen.datatypes.ProtoDataTypes;
 import com.julienviet.protobuf.tests.codegen.validation.InvalidJavaTypeBooleanArray;
 import com.julienviet.protobuf.tests.codegen.validation.InvalidJavaTypeByte;
 import com.julienviet.protobuf.tests.codegen.validation.InvalidJavaTypeDoubleArray;
@@ -24,6 +25,8 @@ import com.julienviet.protobuf.tests.codegen.validation.InvalidJavaTypeIntArray;
 import com.julienviet.protobuf.tests.codegen.validation.InvalidJavaTypeLongArray;
 import com.julienviet.protobuf.tests.codegen.validation.InvalidJavaTypeShort;
 import com.julienviet.protobuf.tests.codegen.validation.InvalidJavaTypeShortArray;
+import com.julienviet.protobuf.tests.codegen.validation.InvalidProtoTypeInt32;
+import com.julienviet.protobuf.tests.codegen.validation.InvalidProtoTypeInt64;
 import io.vertx.codegen.processor.Compiler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
@@ -304,6 +307,43 @@ public class ProcessorTest {
   }
 
   @Test
+  public void testProtoDataTypes() {
+    MessageMappers mappers = assertCompile(ProtoDataTypes.class);
+    MessageMapper<ProtoDataTypes> mapper = mappers.of(ProtoDataTypes.class);
+    MessageType ml = mapper.literal();
+    Field f1 = ml.field(1);
+    assertEquals("int32Field", f1.jsonName());
+    assertEquals(ScalarType.INT32, f1.type());
+    Field f2 = ml.field(2);
+    assertEquals("uint32Field", f2.jsonName());
+    assertEquals(ScalarType.UINT32, f2.type());
+    Field f3 = ml.field(3);
+    assertEquals("sint32Field", f3.jsonName());
+    assertEquals(ScalarType.SINT32, f3.type());
+    Field f4 = ml.field(4);
+    assertEquals("fixed32Field", f4.jsonName());
+    assertEquals(ScalarType.FIXED32, f4.type());
+    Field f5 = ml.field(5);
+    assertEquals("sfixed32Field", f5.jsonName());
+    assertEquals(ScalarType.SFIXED32, f5.type());
+    Field f6 = ml.field(6);
+    assertEquals("int64Field", f6.jsonName());
+    assertEquals(ScalarType.INT64, f6.type());
+    Field f7 = ml.field(7);
+    assertEquals("uint64Field", f7.jsonName());
+    assertEquals(ScalarType.UINT64, f7.type());
+    Field f8 = ml.field(8);
+    assertEquals("sint64Field", f8.jsonName());
+    assertEquals(ScalarType.SINT64, f8.type());
+    Field f9 = ml.field(9);
+    assertEquals("fixed64Field", f9.jsonName());
+    assertEquals(ScalarType.FIXED64, f9.type());
+    Field f10 = ml.field(10);
+    assertEquals("sfixed64Field", f10.jsonName());
+    assertEquals(ScalarType.SFIXED64, f10.type());
+  }
+
+  @Test
   public void testEmbedded() {
     MessageMappers mappers = assertCompile(EmbeddedContainer.class, Embedded.class);
     MessageMapper<EmbeddedContainer> mapper = mappers.of(EmbeddedContainer.class);
@@ -499,5 +539,9 @@ public class ProcessorTest {
     assertEquals(ValidationError.INVALID_FIELD_TYPE, expected.getError());
     expected = (ValidationException) assertCompilationFailure(InvalidJavaTypeShortArray.class);
     assertEquals(ValidationError.INVALID_FIELD_TYPE, expected.getError());
+    expected = (ValidationException) assertCompilationFailure(InvalidProtoTypeInt32.class);
+    assertEquals(ValidationError.INVALID_FIELD_TYPE_MISMATCH, expected.getError());
+    expected = (ValidationException) assertCompilationFailure(InvalidProtoTypeInt64.class);
+    assertEquals(ValidationError.INVALID_FIELD_TYPE_MISMATCH, expected.getError());
   }
 }

--- a/protobuf-codegen/src/test/java/com/julienviet/protobuf/tests/codegen/datatypes/ProtoDataTypes.java
+++ b/protobuf-codegen/src/test/java/com/julienviet/protobuf/tests/codegen/datatypes/ProtoDataTypes.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2025 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.julienviet.protobuf.tests.codegen.datatypes;
+
+import com.julienviet.protobuf.lang.ProtoField;
+import com.julienviet.protobuf.lang.ProtoMessage;
+import com.julienviet.protobuf.schema.TypeID;
+
+@ProtoMessage
+public class ProtoDataTypes {
+
+  private int int32Field;
+  private int uint32Field;
+  private int sint32Field;
+  private int fixed32Field;
+  private int sfixed32Field;
+  private long int64Field;
+  private long uint64Field;
+  private long sint64Field;
+  private long fixed64Field;
+  private long sfixed64Field;
+
+  @ProtoField(number = 1, protoName = "int32_field", type = TypeID.INT32)
+  public int getInt32Field() {
+    return int32Field;
+  }
+
+  public void setInt32Field(int i) {
+    this.int32Field = i;
+  }
+
+  @ProtoField(number = 2, protoName = "uint32_field", type = TypeID.UINT32)
+  public int getUint32Field() {
+    return uint32Field;
+  }
+
+  public void setUint32Field(int i) {
+    this.uint32Field = i;
+  }
+
+  @ProtoField(number = 3, protoName = "sint32_field", type = TypeID.SINT32)
+  public int getSint32Field() {
+    return sint32Field;
+  }
+
+  public void setSint32Field(int i) {
+    this.sint32Field = i;
+  }
+
+  @ProtoField(number = 4, protoName = "fixed32_field", type = TypeID.FIXED32)
+  public int getFixed32Field() {
+    return fixed32Field;
+  }
+
+  public void setFixed32Field(int i) {
+    this.fixed32Field = i;
+  }
+
+  @ProtoField(number = 5, protoName = "sfixed32_field", type = TypeID.SFIXED32)
+  public int getSfixed32Field() {
+    return sfixed32Field;
+  }
+
+  public void setSfixed32Field(int i) {
+    this.sfixed32Field = i;
+  }
+
+  @ProtoField(number = 6, protoName = "int64_field", type = TypeID.INT64)
+  public long getInt64Field() {
+    return int64Field;
+  }
+
+  public void setInt64Field(long i) {
+    this.int64Field = i;
+  }
+
+  @ProtoField(number = 7, protoName = "uint64_field", type = TypeID.UINT64)
+  public long getUint64Field() {
+    return uint64Field;
+  }
+
+  public void setUint64Field(long i) {
+    this.uint64Field = i;
+  }
+
+  @ProtoField(number = 8, protoName = "sint64_field", type = TypeID.SINT64)
+  public long getSint64Field() {
+    return sint64Field;
+  }
+
+  public void setSint64Field(long i) {
+    this.sint64Field = i;
+  }
+
+  @ProtoField(number = 9, protoName = "fixed64_field", type = TypeID.FIXED64)
+  public long getFixed64Field() {
+    return fixed64Field;
+  }
+
+  public void setFixed64Field(long i) {
+    this.fixed64Field = i;
+  }
+
+  @ProtoField(number = 10, protoName = "sfixed64_field", type = TypeID.SFIXED64)
+  public long getSfixed64Field() {
+    return sfixed64Field;
+  }
+
+  public void setSfixed64Field(long i) {
+    this.sfixed64Field = i;
+  }
+}

--- a/protobuf-codegen/src/test/java/com/julienviet/protobuf/tests/codegen/validation/InvalidProtoTypeInt32.java
+++ b/protobuf-codegen/src/test/java/com/julienviet/protobuf/tests/codegen/validation/InvalidProtoTypeInt32.java
@@ -14,15 +14,20 @@
  * limitations under the License.
  *
  */
-package com.julienviet.protobuf.codegen;
+package com.julienviet.protobuf.tests.codegen.validation;
 
-public enum ValidationError {
+import com.julienviet.protobuf.lang.ProtoField;
+import com.julienviet.protobuf.lang.ProtoMessage;
+import com.julienviet.protobuf.schema.TypeID;
 
-  MISSING_GETTER,
-  MISSING_SETTER,
-  INVALID_FIELD_METHOD,
-  INVALID_MESSAGE_CLASS,
-  INVALID_FIELD_TYPE,
-  INVALID_FIELD_TYPE_MISMATCH,
+@ProtoMessage
+public class InvalidProtoTypeInt32 {
 
+  @ProtoField(number = 1, type = TypeID.INT64)
+  public int getFoo() {
+    throw new UnsupportedOperationException();
+  }
+
+  public void setFoo(int s) {
+  }
 }

--- a/protobuf-codegen/src/test/java/com/julienviet/protobuf/tests/codegen/validation/InvalidProtoTypeInt64.java
+++ b/protobuf-codegen/src/test/java/com/julienviet/protobuf/tests/codegen/validation/InvalidProtoTypeInt64.java
@@ -14,15 +14,20 @@
  * limitations under the License.
  *
  */
-package com.julienviet.protobuf.codegen;
+package com.julienviet.protobuf.tests.codegen.validation;
 
-public enum ValidationError {
+import com.julienviet.protobuf.lang.ProtoField;
+import com.julienviet.protobuf.lang.ProtoMessage;
+import com.julienviet.protobuf.schema.TypeID;
 
-  MISSING_GETTER,
-  MISSING_SETTER,
-  INVALID_FIELD_METHOD,
-  INVALID_MESSAGE_CLASS,
-  INVALID_FIELD_TYPE,
-  INVALID_FIELD_TYPE_MISMATCH,
+@ProtoMessage
+public class InvalidProtoTypeInt64 {
 
+  @ProtoField(number = 1, type = TypeID.BOOL)
+  public long getFoo() {
+    throw new UnsupportedOperationException();
+  }
+
+  public void setFoo(long s) {
+  }
 }


### PR DESCRIPTION
Implement proto field type override, to force a different proto type than the default java to proto type mapping.